### PR TITLE
remove source tar to reduce image size by ~9mb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbea
     mv /metricbeat/metricbeat.yml /metricbeat/metricbeat.example.yml && \
     mv /metricbeat/metricbeat /bin/metricbeat && \
     chmod +x /bin/metricbeat && \
-    mkdir -p /metricbeat/config /metricbeat/data
+    mkdir -p /metricbeat/config /metricbeat/data && \
+    rm metricbeat-${METRICBEAT_VERSION}-linux-x86_64.tar.gz
 
 WORKDIR /metricbeat
 


### PR DESCRIPTION
Reduce image footprint by ~9mb by removing the unused originally downloaded source tarball